### PR TITLE
Add deployment of frontend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,34 @@ jobs:
         with:
           name: cyber_query_ai
           path: dist/cyber_query_ai-*-py3-none-any.whl
+
+  build_frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "npm"
+          cache-dependency-path: "cyber-query-ai-frontend/package-lock.json"
+      - name: Install frontend dependencies
+        run: |
+          cd cyber-query-ai-frontend
+          npm ci
+      - name: Build frontend
+        run: |
+          cd cyber-query-ai-frontend
+          npm run build
+      - name: Upload frontend build
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend_build
+          path: cyber-query-ai-frontend/out
+
   create_installer:
     runs-on: ubuntu-latest
-    needs: build_wheel
+    needs: [build_wheel, build_frontend]
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
@@ -45,10 +70,15 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version-file: ".python-version"
-      - name: Download artifact from build job
+      - name: Download backend artifact
         uses: actions/download-artifact@v4
         with:
           name: cyber_query_ai
+      - name: Download frontend build
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend_build
+          path: static
       - name: Prepare release directory
         run: |
           PACKAGE_NAME="cyber_query_ai"
@@ -57,6 +87,7 @@ jobs:
 
           mv "$WHEEL_FILE" release/
           mv config.json release/
+          mv static release/
           chmod +x release/install_cyber_query_ai.sh
           mv release ${PACKAGE_NAME}_${PACKAGE_VERSION}
 
@@ -111,6 +142,11 @@ jobs:
 
           if [ ! -d ".venv" ]; then
             echo "Virtual environment not found"
+            exit 1
+          fi
+
+          if [ ! -d "static" ]; then
+            echo "Static directory not found"
             exit 1
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+static
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/cyber-query-ai-frontend/eslint.config.mjs
+++ b/cyber-query-ai-frontend/eslint.config.mjs
@@ -12,11 +12,23 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  // Extend Next.js configs
+  ...compat.extends("next"),
+  ...compat.extends("next/core-web-vitals"),
+  ...compat.extends("next/typescript"),
   {
+    files: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
     plugins: {
       prettier: prettierPlugin,
       import: importPlugin,
+    },
+    settings: {
+      next: {
+        rootDir: __dirname,
+      },
+      react: {
+        version: "detect",
+      },
     },
     rules: {
       // Prettier integration

--- a/cyber-query-ai-frontend/next.config.ts
+++ b/cyber-query-ai-frontend/next.config.ts
@@ -1,14 +1,22 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  async rewrites() {
-    return [
-      {
-        source: "/api/:path*",
-        destination: "http://localhost:8000/api/:path*", // FastAPI backend
-      },
-    ];
+  output: "export", // Enable static export
+  trailingSlash: true,
+  images: {
+    unoptimized: true, // Required for static export
   },
+  // Remove rewrites for production static build
+  ...(process.env.NODE_ENV === "development" && {
+    async rewrites() {
+      return [
+        {
+          source: "/api/:path*",
+          destination: "http://localhost:8000/api/:path*", // FastAPI backend
+        },
+      ];
+    },
+  }),
 };
 
 export default nextConfig;

--- a/cyber-query-ai-frontend/src/lib/api.ts
+++ b/cyber-query-ai-frontend/src/lib/api.ts
@@ -2,9 +2,22 @@ import axios from "axios";
 
 import { PromptRequest, CommandGenerationResponse } from "./types";
 
+// Determine the base URL based on environment
+const getBaseURL = () => {
+  if (typeof window === "undefined") return "";
+
+  // In production static build, API is served from same origin
+  if (process.env.NODE_ENV === "production") {
+    return window.location.origin;
+  }
+
+  // In development, proxy to backend (handled by Next.js rewrites)
+  return "";
+};
+
 // API client configuration
 const api = axios.create({
-  baseURL: "/api", // This will be proxied to localhost:8000/api
+  baseURL: getBaseURL() + "/api", // This will be proxied in dev, direct in production
   timeout: 30000, // 30 seconds timeout for LLM responses
   headers: {
     "Content-Type": "application/json",

--- a/cyber_query_ai/main.py
+++ b/cyber_query_ai/main.py
@@ -54,7 +54,7 @@ def create_app(config: Config) -> FastAPI:
     app.state.chatbot = Chatbot(model=config.model)
 
     # Serve static files if they exist
-    static_dir = Path(os.environ.get("CYBER_QUERY_AI_ROOT_DIR", ".")) / "static"
+    static_dir = Path(os.environ.get("CYBER_QUERY_AI_ROOT_DIR", ".") or ".") / "static"
     if static_dir.exists():
         app.mount("/static", StaticFiles(directory=static_dir), name="static")
 

--- a/cyber_query_ai/main.py
+++ b/cyber_query_ai/main.py
@@ -1,12 +1,16 @@
 """Cyber Query AI."""
 
 import json
+import os
 import re
+from pathlib import Path
 
 import uvicorn
 from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from cyber_query_ai.chatbot import Chatbot
 from cyber_query_ai.config import Config, load_config
@@ -42,12 +46,38 @@ def create_app(config: Config) -> FastAPI:
     app = FastAPI()
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=[f"http://{config.host}:{config.port}"],
         allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=["GET", "POST"],
+        allow_headers=["Content-Type"],
     )
     app.state.chatbot = Chatbot(model=config.model)
+
+    # Serve static files if they exist
+    static_dir = Path(os.environ.get("CYBER_QUERY_AI_ROOT_DIR", ".")) / "static"
+    if static_dir.exists():
+        app.mount("/static", StaticFiles(directory=static_dir), name="static")
+
+        # Serve index.html for SPA routing (must be defined after API routes)
+        @app.get("/{full_path:path}")
+        async def serve_spa(full_path: str) -> FileResponse:
+            """Serve the SPA for all non-API routes."""
+            # Skip API routes - they should be handled by the API router
+            if full_path.startswith("api/"):
+                raise HTTPException(status_code=404, detail="API endpoint not found")
+
+            # Serve specific static files
+            file_path = static_dir / full_path
+            if file_path.is_file():
+                return FileResponse(file_path)
+
+            # Fallback to index.html for SPA routing
+            index_path = static_dir / "index.html"
+            if index_path.exists():
+                return FileResponse(index_path)
+
+            raise HTTPException(status_code=404, detail="File not found")
+
     return app
 
 
@@ -92,6 +122,7 @@ def run() -> None:
     """Run the FastAPI app using uvicorn."""
     config = load_config()
     app = create_app(config)
+    # Include API router before any catch-all routes
     app.include_router(api_router)
     uvicorn.run(
         app,


### PR DESCRIPTION
This pull request adds static frontend build support to the project, enabling the frontend to be built, exported, and served as static files by the backend. The CI workflow is updated to build and package the frontend, and the backend is modified to serve static files and support SPA routing. Additionally, the frontend configuration is updated for static export compatibility and the API client is adjusted to work correctly in both development and production environments.

**Frontend Build & Packaging Integration**
* Added a new `build_frontend` job to `.github/workflows/build.yml` that installs dependencies, builds the frontend, and uploads the static build artifacts. The `create_installer` job now depends on both backend and frontend builds and packages the static frontend files into the release. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R34-R61) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L48-R81) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R90)
* Added a check in the installer workflow to ensure the static frontend directory exists before packaging.

**Frontend Static Export Configuration**
* Updated `cyber-query-ai-frontend/next.config.ts` to enable static export (`output: "export"`), trailing slashes, and unoptimized images for compatibility. Rewrites are now only included in development mode. [[1]](diffhunk://#diff-7be63be8b7ab46277018d8c97029d4b00467ca6efeb8fac0c1978b07214a24ccR4-R10) [[2]](diffhunk://#diff-7be63be8b7ab46277018d8c97029d4b00467ca6efeb8fac0c1978b07214a24ccR19)

**Frontend Linting and API Configuration**
* Improved ESLint configuration for Next.js and React, including environment-specific settings and plugin integration in `cyber-query-ai-frontend/eslint.config.mjs`.
* Updated `cyber-query-ai-frontend/src/lib/api.ts` to dynamically determine the API base URL for production (static build) and development environments, ensuring API requests work in both cases.

**Backend Static File Serving**
* Modified `cyber_query_ai/main.py` to serve static files from a `static` directory, including a catch-all route for SPA routing (serving `index.html` for non-API routes). CORS settings are restricted to only allow requests from the configured host and port, and only GET/POST methods. [[1]](diffhunk://#diff-162499962760bfef43f51dc36de7439f0b37d89e0a80f5cdaea253534d64ea6cR4-R13) [[2]](diffhunk://#diff-162499962760bfef43f51dc36de7439f0b37d89e0a80f5cdaea253534d64ea6cL45-R80) [[3]](diffhunk://#diff-162499962760bfef43f51dc36de7439f0b37d89e0a80f5cdaea253534d64ea6cR125)