### PR TITLE
Add health endpoint

### DIFF
--- a/cyber-query-ai-frontend/src/components/HealthIndicator.tsx
+++ b/cyber-query-ai-frontend/src/components/HealthIndicator.tsx
@@ -1,0 +1,48 @@
+import { useHealthStatus, type HealthStatus } from "@/lib/useHealthStatus";
+
+function HealthIndicator() {
+  const status = useHealthStatus();
+
+  const getStatusColor = (status: HealthStatus): string => {
+    switch (status) {
+      case "online":
+        return "text-green-400";
+      case "offline":
+        return "text-red-400";
+      case "checking":
+        return "text-yellow-400";
+      default:
+        return "text-gray-400";
+    }
+  };
+
+  const getStatusIcon = (status: HealthStatus): string => {
+    switch (status) {
+      case "online":
+        return "🟢";
+      case "offline":
+        return "🔴";
+      case "checking":
+        return "🟡";
+      default:
+        return "⚪";
+    }
+  };
+
+  const getStatusText = (status: HealthStatus): string => {
+    return `Server: ${status.toUpperCase()}`;
+  };
+
+  return (
+    <div className="relative group">
+      <div
+        className={`text-sm cursor-help ${getStatusColor(status)}`}
+        title={getStatusText(status)}
+      >
+        {getStatusIcon(status)}
+      </div>
+    </div>
+  );
+}
+
+export default HealthIndicator;

--- a/cyber-query-ai-frontend/src/components/Navigation.tsx
+++ b/cyber-query-ai-frontend/src/components/Navigation.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+import HealthIndicator from "./HealthIndicator";
+
 const Navigation = () => {
   const pathname = usePathname();
 
@@ -43,7 +45,7 @@ const Navigation = () => {
       <div className="w-full px-4 sm:px-6 lg:px-8">
         <div className="flex items-center h-16 w-full justify-between">
           {/* Logo */}
-          <div className="flex items-center">
+          <div className="flex items-center space-x-4">
             <Link href="/" className="flex items-center space-x-2">
               <div className="text-2xl font-bold neon-glow text-[var(--text-primary)]">
                 CyberQueryAI
@@ -52,6 +54,7 @@ const Navigation = () => {
                 v0.1.0
               </div>
             </Link>
+            <HealthIndicator />
           </div>
 
           {/* Navigation Links */}

--- a/cyber-query-ai-frontend/src/components/Navigation.tsx
+++ b/cyber-query-ai-frontend/src/components/Navigation.tsx
@@ -3,6 +3,8 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+import { version } from "../lib/version";
+
 import HealthIndicator from "./HealthIndicator";
 
 const Navigation = () => {
@@ -51,7 +53,7 @@ const Navigation = () => {
                 CyberQueryAI
               </div>
               <div className="text-xs text-[var(--text-muted)] hidden sm:block">
-                v0.1.0
+                v{version}
               </div>
             </Link>
             <HealthIndicator />

--- a/cyber-query-ai-frontend/src/components/__tests__/HealthIndicator.test.tsx
+++ b/cyber-query-ai-frontend/src/components/__tests__/HealthIndicator.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { HealthStatus, useHealthStatus } from "../../lib/useHealthStatus";
+import HealthIndicator from "../HealthIndicator";
+
+// Mock the useHealthStatus hook
+jest.mock("../../lib/useHealthStatus", () => ({
+  useHealthStatus: jest.fn(),
+}));
+
+const mockUseHealthStatus = useHealthStatus as jest.MockedFunction<
+  typeof useHealthStatus
+>;
+
+describe("HealthIndicator", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders online status correctly", () => {
+    mockUseHealthStatus.mockReturnValue("online");
+
+    render(<HealthIndicator />);
+
+    const icon = screen.getByText("🟢");
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass("text-green-400");
+    expect(icon).toHaveAttribute("title", "Server: ONLINE");
+  });
+
+  it("renders offline status correctly", () => {
+    mockUseHealthStatus.mockReturnValue("offline");
+
+    render(<HealthIndicator />);
+
+    const icon = screen.getByText("🔴");
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass("text-red-400");
+    expect(icon).toHaveAttribute("title", "Server: OFFLINE");
+  });
+
+  it("renders checking status correctly", () => {
+    mockUseHealthStatus.mockReturnValue("checking");
+
+    render(<HealthIndicator />);
+
+    const icon = screen.getByText("🟡");
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass("text-yellow-400");
+    expect(icon).toHaveAttribute("title", "Server: CHECKING");
+  });
+
+  it("applies correct CSS classes for container", () => {
+    mockUseHealthStatus.mockReturnValue("online");
+
+    const { container } = render(<HealthIndicator />);
+
+    const outerDiv = container.firstChild;
+    expect(outerDiv).toHaveClass("relative", "group");
+  });
+
+  it("applies cursor-help class for interactivity indication", () => {
+    mockUseHealthStatus.mockReturnValue("online");
+
+    render(<HealthIndicator />);
+
+    const icon = screen.getByText("🟢");
+    expect(icon).toHaveClass("cursor-help");
+  });
+
+  it("renders with correct text size", () => {
+    mockUseHealthStatus.mockReturnValue("online");
+
+    render(<HealthIndicator />);
+
+    const icon = screen.getByText("🟢");
+    expect(icon).toHaveClass("text-sm");
+  });
+
+  it("handles unknown status gracefully", () => {
+    // This shouldn't happen in practice, but test edge case
+    mockUseHealthStatus.mockReturnValue("unknown" as HealthStatus);
+
+    render(<HealthIndicator />);
+
+    const icon = screen.getByText("⚪");
+    expect(icon).toBeInTheDocument();
+    expect(icon).toHaveClass("text-gray-400");
+    expect(icon).toHaveAttribute("title", "Server: UNKNOWN");
+  });
+
+  it("calls useHealthStatus hook", () => {
+    mockUseHealthStatus.mockReturnValue("online");
+
+    render(<HealthIndicator />);
+
+    expect(mockUseHealthStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders only the icon without additional text", () => {
+    mockUseHealthStatus.mockReturnValue("online");
+
+    render(<HealthIndicator />);
+
+    expect(screen.getByText("🟢")).toBeInTheDocument();
+    expect(screen.queryByText("Server:")).not.toBeInTheDocument();
+    expect(screen.queryByText("ONLINE")).not.toBeInTheDocument();
+  });
+});

--- a/cyber-query-ai-frontend/src/components/__tests__/Navigation.test.tsx
+++ b/cyber-query-ai-frontend/src/components/__tests__/Navigation.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react";
 import React from "react";
 
 import { useHealthStatus } from "../../lib/useHealthStatus";
+import { version } from "../../lib/version";
 import Navigation from "../Navigation";
 
 // Mock Next.js Link component
@@ -44,7 +45,7 @@ describe("Navigation", () => {
 
   it("renders version number", () => {
     render(<Navigation />);
-    expect(screen.getByText("v0.1.0")).toBeInTheDocument();
+    expect(screen.getByText(`v${version}`)).toBeInTheDocument();
   });
 
   it("renders all navigation items", () => {

--- a/cyber-query-ai-frontend/src/components/__tests__/Navigation.test.tsx
+++ b/cyber-query-ai-frontend/src/components/__tests__/Navigation.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
 
+import { useHealthStatus } from "../../lib/useHealthStatus";
 import Navigation from "../Navigation";
 
 // Mock Next.js Link component
@@ -22,7 +23,20 @@ jest.mock("next/link", () => {
   return MockLink;
 });
 
+// Mock the useHealthStatus hook
+jest.mock("../../lib/useHealthStatus", () => ({
+  useHealthStatus: jest.fn(),
+}));
+
+const mockUseHealthStatus = useHealthStatus as jest.MockedFunction<
+  typeof useHealthStatus
+>;
+
 describe("Navigation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseHealthStatus.mockReturnValue("online");
+  });
   it("renders the CyberQueryAI logo", () => {
     render(<Navigation />);
     expect(screen.getByText("CyberQueryAI")).toBeInTheDocument();
@@ -87,5 +101,78 @@ describe("Navigation", () => {
       name: /Script Gen \(Soon\)/,
     });
     expect(scriptGenLink).toHaveClass("cursor-not-allowed", "opacity-50");
+  });
+
+  describe("HealthIndicator integration", () => {
+    it("renders HealthIndicator in the navigation", () => {
+      mockUseHealthStatus.mockReturnValue("online");
+
+      render(<Navigation />);
+
+      // The HealthIndicator should render an icon
+      expect(screen.getByText("🟢")).toBeInTheDocument();
+    });
+
+    it("displays online status icon when server is online", () => {
+      mockUseHealthStatus.mockReturnValue("online");
+
+      render(<Navigation />);
+
+      expect(screen.getByText("🟢")).toBeInTheDocument();
+      expect(screen.queryByText("🔴")).not.toBeInTheDocument();
+      expect(screen.queryByText("🟡")).not.toBeInTheDocument();
+    });
+
+    it("displays offline status icon when server is offline", () => {
+      mockUseHealthStatus.mockReturnValue("offline");
+
+      render(<Navigation />);
+
+      expect(screen.getByText("🔴")).toBeInTheDocument();
+      expect(screen.queryByText("🟢")).not.toBeInTheDocument();
+      expect(screen.queryByText("🟡")).not.toBeInTheDocument();
+    });
+
+    it("displays checking status icon when status is being checked", () => {
+      mockUseHealthStatus.mockReturnValue("checking");
+
+      render(<Navigation />);
+
+      expect(screen.getByText("🟡")).toBeInTheDocument();
+      expect(screen.queryByText("🟢")).not.toBeInTheDocument();
+      expect(screen.queryByText("🔴")).not.toBeInTheDocument();
+    });
+
+    it("positions HealthIndicator next to the logo", () => {
+      mockUseHealthStatus.mockReturnValue("online");
+
+      render(<Navigation />);
+
+      // Check that both the logo and health indicator are present
+      expect(screen.getByText("CyberQueryAI")).toBeInTheDocument();
+      expect(screen.getByText("🟢")).toBeInTheDocument();
+
+      // Check that they are both in the navigation
+      const nav = screen.getByRole("navigation");
+      expect(nav).toContainElement(screen.getByText("CyberQueryAI"));
+      expect(nav).toContainElement(screen.getByText("🟢"));
+    });
+
+    it("includes tooltip with status information", () => {
+      mockUseHealthStatus.mockReturnValue("online");
+
+      render(<Navigation />);
+
+      const healthIcon = screen.getByText("🟢");
+      expect(healthIcon).toHaveAttribute("title", "Server: ONLINE");
+    });
+
+    it("calls useHealthStatus hook when Navigation is rendered", () => {
+      mockUseHealthStatus.mockReturnValue("online");
+
+      render(<Navigation />);
+
+      expect(mockUseHealthStatus).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/cyber-query-ai-frontend/src/lib/__tests__/useHealthStatus.test.ts
+++ b/cyber-query-ai-frontend/src/lib/__tests__/useHealthStatus.test.ts
@@ -1,0 +1,181 @@
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+import { useHealthStatus, type HealthStatus } from "../useHealthStatus";
+
+// Mock fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe("useHealthStatus", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("should initialize with 'checking' status", () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+    });
+
+    const { result } = renderHook(() => useHealthStatus());
+
+    expect(result.current).toBe("checking");
+  });
+
+  it("should set status to 'online' when fetch succeeds", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+    });
+
+    const { result } = renderHook(() => useHealthStatus());
+
+    await waitFor(() => {
+      expect(result.current).toBe("online");
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/health");
+  });
+
+  it("should set status to 'offline' when fetch fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    const { result } = renderHook(() => useHealthStatus());
+
+    await waitFor(() => {
+      expect(result.current).toBe("offline");
+    });
+  });
+
+  it("should set status to 'offline' when response is not ok", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    const { result } = renderHook(() => useHealthStatus());
+
+    await waitFor(() => {
+      expect(result.current).toBe("offline");
+    });
+  });
+
+  it("should poll every 30 seconds", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+    });
+
+    renderHook(() => useHealthStatus());
+
+    // Initial call
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Advance time by 30 seconds
+    act(() => {
+      jest.advanceTimersByTime(30000);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // Advance time by another 30 seconds
+    act(() => {
+      jest.advanceTimersByTime(30000);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("should clear interval on unmount", () => {
+    const clearIntervalSpy = jest.spyOn(global, "clearInterval");
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+    });
+
+    const { unmount } = renderHook(() => useHealthStatus());
+
+    unmount();
+
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    clearIntervalSpy.mockRestore();
+  });
+
+  it("should handle multiple status changes correctly", async () => {
+    // First call succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+    });
+
+    const { result } = renderHook(() => useHealthStatus());
+
+    await waitFor(() => {
+      expect(result.current).toBe("online");
+    });
+
+    // Second call fails
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    act(() => {
+      jest.advanceTimersByTime(30000);
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe("offline");
+    });
+
+    // Third call succeeds again
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(30000);
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe("online");
+    });
+  });
+
+  it("should call fetch with correct URL", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+    });
+
+    renderHook(() => useHealthStatus());
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/health");
+  });
+
+  it("should handle fetch throwing an error", async () => {
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mockFetch.mockImplementationOnce(() => {
+      throw new Error("Fetch failed");
+    });
+
+    const { result } = renderHook(() => useHealthStatus());
+
+    await waitFor(() => {
+      expect(result.current).toBe("offline");
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it("should return the correct type", () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+    });
+
+    const { result } = renderHook(() => useHealthStatus());
+
+    // Type check - result.current should be assignable to HealthStatus
+    const status: HealthStatus = result.current;
+    expect(["checking", "online", "offline"]).toContain(status);
+  });
+});

--- a/cyber-query-ai-frontend/src/lib/__tests__/useHealthStatus.test.ts
+++ b/cyber-query-ai-frontend/src/lib/__tests__/useHealthStatus.test.ts
@@ -29,6 +29,11 @@ describe("useHealthStatus", () => {
   it("should set status to 'online' when fetch succeeds", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
+      json: () =>
+        Promise.resolve({
+          status: "healthy",
+          timestamp: "2023-01-01T00:00:00Z",
+        }),
     });
 
     const { result } = renderHook(() => useHealthStatus());
@@ -66,6 +71,11 @@ describe("useHealthStatus", () => {
   it("should poll every 30 seconds", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
+      json: () =>
+        Promise.resolve({
+          status: "healthy",
+          timestamp: "2023-01-01T00:00:00Z",
+        }),
     });
 
     renderHook(() => useHealthStatus());
@@ -93,6 +103,11 @@ describe("useHealthStatus", () => {
 
     mockFetch.mockResolvedValue({
       ok: true,
+      json: () =>
+        Promise.resolve({
+          status: "healthy",
+          timestamp: "2023-01-01T00:00:00Z",
+        }),
     });
 
     const { unmount } = renderHook(() => useHealthStatus());
@@ -107,6 +122,11 @@ describe("useHealthStatus", () => {
     // First call succeeds
     mockFetch.mockResolvedValueOnce({
       ok: true,
+      json: () =>
+        Promise.resolve({
+          status: "healthy",
+          timestamp: "2023-01-01T00:00:00Z",
+        }),
     });
 
     const { result } = renderHook(() => useHealthStatus());
@@ -129,6 +149,11 @@ describe("useHealthStatus", () => {
     // Third call succeeds again
     mockFetch.mockResolvedValueOnce({
       ok: true,
+      json: () =>
+        Promise.resolve({
+          status: "healthy",
+          timestamp: "2023-01-01T00:00:00Z",
+        }),
     });
 
     act(() => {
@@ -143,6 +168,11 @@ describe("useHealthStatus", () => {
   it("should call fetch with correct URL", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
+      json: () =>
+        Promise.resolve({
+          status: "healthy",
+          timestamp: "2023-01-01T00:00:00Z",
+        }),
     });
 
     renderHook(() => useHealthStatus());
@@ -170,6 +200,11 @@ describe("useHealthStatus", () => {
   it("should return the correct type", () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
+      json: () =>
+        Promise.resolve({
+          status: "healthy",
+          timestamp: "2023-01-01T00:00:00Z",
+        }),
     });
 
     const { result } = renderHook(() => useHealthStatus());

--- a/cyber-query-ai-frontend/src/lib/__tests__/version.test.ts
+++ b/cyber-query-ai-frontend/src/lib/__tests__/version.test.ts
@@ -1,0 +1,7 @@
+import { version } from "../version";
+
+describe("version", () => {
+  it("should return the correct version from package.json", () => {
+    expect(version).toBe("0.1.0");
+  });
+});

--- a/cyber-query-ai-frontend/src/lib/types.ts
+++ b/cyber-query-ai-frontend/src/lib/types.ts
@@ -6,6 +6,11 @@ export interface PromptRequest {
 }
 
 // Response types
+export interface HealthResponse {
+  status: string;
+  timestamp: string;
+}
+
 export interface CommandGenerationResponse {
   commands: string[];
   explanation: string;

--- a/cyber-query-ai-frontend/src/lib/useHealthStatus.ts
+++ b/cyber-query-ai-frontend/src/lib/useHealthStatus.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import type { HealthResponse } from "./types";
+
 export type HealthStatus = "online" | "offline" | "checking";
 
 export function useHealthStatus(): HealthStatus {
@@ -10,7 +12,12 @@ export function useHealthStatus(): HealthStatus {
       try {
         const res = await fetch("/api/health");
         if (res.ok) {
-          setStatus("online");
+          const data: HealthResponse = await res.json();
+          if (data.status === "healthy") {
+            setStatus("online");
+          } else {
+            setStatus("offline");
+          }
         } else {
           setStatus("offline");
         }

--- a/cyber-query-ai-frontend/src/lib/useHealthStatus.ts
+++ b/cyber-query-ai-frontend/src/lib/useHealthStatus.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+export type HealthStatus = "online" | "offline" | "checking";
+
+export function useHealthStatus(): HealthStatus {
+  const [status, setStatus] = useState<HealthStatus>("checking");
+
+  useEffect(() => {
+    const checkHealth = async () => {
+      try {
+        const res = await fetch("/api/health");
+        if (res.ok) {
+          setStatus("online");
+        } else {
+          setStatus("offline");
+        }
+      } catch {
+        setStatus("offline");
+      }
+    };
+
+    checkHealth();
+    const interval = setInterval(checkHealth, 30000); // every 30s
+    return () => clearInterval(interval);
+  }, []);
+
+  return status;
+}

--- a/cyber-query-ai-frontend/src/lib/version.ts
+++ b/cyber-query-ai-frontend/src/lib/version.ts
@@ -1,0 +1,3 @@
+import packageJson from "../../package.json";
+
+export const version = packageJson.version;

--- a/cyber_query_ai/api.py
+++ b/cyber_query_ai/api.py
@@ -1,13 +1,14 @@
 """API router for the CyberQueryAI application."""
 
 import json
+from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.concurrency import run_in_threadpool
 from slowapi import Limiter
 
 from cyber_query_ai.helpers import clean_json_response, sanitize_text
-from cyber_query_ai.models import CommandGenerationResponse, PromptRequest
+from cyber_query_ai.models import CommandGenerationResponse, HealthResponse, PromptRequest
 
 LIMITER_INTERVAL = "5/minute"
 
@@ -23,6 +24,12 @@ def get_api_router() -> APIRouter:
 def get_limiter() -> Limiter:
     """Get the rate limiter."""
     return limiter
+
+
+@api_router.get("/health", response_model=HealthResponse)
+async def health_check() -> HealthResponse:
+    """Check the health of the server."""
+    return HealthResponse(status="ok", timestamp=datetime.now().isoformat() + "Z")
 
 
 @api_router.post("/generate-command", response_model=CommandGenerationResponse)

--- a/cyber_query_ai/api.py
+++ b/cyber_query_ai/api.py
@@ -29,7 +29,7 @@ def get_limiter() -> Limiter:
 @api_router.get("/health", response_model=HealthResponse)
 async def health_check() -> HealthResponse:
     """Check the health of the server."""
-    return HealthResponse(status="ok", timestamp=datetime.now().isoformat() + "Z")
+    return HealthResponse(status="healthy", timestamp=datetime.now().isoformat() + "Z")
 
 
 @api_router.post("/generate-command", response_model=CommandGenerationResponse)

--- a/cyber_query_ai/models.py
+++ b/cyber_query_ai/models.py
@@ -11,6 +11,13 @@ class PromptRequest(BaseModel):
 
 
 # Response schema
+class HealthResponse(BaseModel):
+    """Response model for health check."""
+
+    status: str
+    timestamp: str
+
+
 class CommandGenerationResponse(BaseModel):
     """Response model for command generation."""
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -60,7 +60,7 @@ class TestHealthCheck:
 
         assert response.status_code == HTTP_OK
         data = response.json()
-        assert data["status"] == "ok"
+        assert data["status"] == "healthy"
         assert "timestamp" in data
         assert data["timestamp"].endswith("Z")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -51,6 +51,20 @@ def test_app() -> TestClient:
     return TestClient(app)
 
 
+class TestHealthCheck:
+    """Tests for the health check endpoint."""
+
+    def test_health_check_success(self, test_app: TestClient) -> None:
+        """Test successful health check."""
+        response = test_app.get("/api/health")
+
+        assert response.status_code == HTTP_OK
+        data = response.json()
+        assert data["status"] == "ok"
+        assert "timestamp" in data
+        assert data["timestamp"].endswith("Z")
+
+
 class TestGenerateCommand:
     """Integration tests for the generate_command endpoint."""
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,18 @@
 """Unit tests for the cyber_query_ai.models module."""
 
-from cyber_query_ai.models import CommandGenerationResponse, PromptRequest
+from cyber_query_ai.models import CommandGenerationResponse, HealthResponse, PromptRequest
+
+
+class TestHealthResponse:
+    """Unit tests for the HealthResponse model."""
+
+    def test_model_dump(self) -> None:
+        """Test the model_dump method."""
+        status = "ok"
+        timestamp = "<timestamp>"
+        response = HealthResponse(status=status, timestamp=timestamp)
+        expected = {"status": status, "timestamp": timestamp}
+        assert response.model_dump() == expected
 
 
 class TestPromptRequest:


### PR DESCRIPTION
This pull request introduces a server health status indicator to the frontend and backend of CyberQueryAI, allowing users to see the live status of the API server directly in the navigation bar. It adds a new `/api/health` endpoint, a React hook to poll this endpoint, a UI component to display health status, and comprehensive tests for all new functionality.

**Backend Health Check Feature:**
* Added a `/api/health` endpoint that returns a `HealthResponse` with status and timestamp, enabling the frontend to poll for server health. [[1]](diffhunk://#diff-3b28ac99e942ad8e061e671d6d21d0929b53b9ba239087ba38b79b3751f84453R29-R34) [[2]](diffhunk://#diff-2fa89f695d65b0930879b6ef532eea2bfa76de081d27af139ab387b0a899e6beR14-R20)
* Added unit and integration tests for the new health endpoint and response model in `tests/test_api.py` and `tests/test_models.py`. [[1]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R54-R67) [[2]](diffhunk://#diff-0adb667cd397bd56edce10eec11e1b10821740a10d72bd148b09645fc9108968L3-R15)

**Frontend Health Indicator Integration:**
* Implemented the `useHealthStatus` React hook to poll `/api/health` every 30 seconds and return the current health status. [[1]](diffhunk://#diff-0b94019251d966d17531e464ec218fedfae32e2693f6ea86d33c3fba3700a87aR1-R35) [[2]](diffhunk://#diff-8a40055b584661825aac3ed28064f6d68bfc20f7f5504ee1277bdc497f4e2f2fR9-R13)
* Created the `HealthIndicator` component to display server status (online/offline/checking) as an icon with tooltip, and integrated it into the navigation bar next to the logo. [[1]](diffhunk://#diff-2cb786daf9eb35b23873762d3e78878a1500646c4cf9565ca206362c8dd3721eR1-R48) [[2]](diffhunk://#diff-a41fcecdd9e0138c1809c739cc16508463e1c4e535c62524f86ed49fc1250d02L46-R59) [[3]](diffhunk://#diff-a41fcecdd9e0138c1809c739cc16508463e1c4e535c62524f86ed49fc1250d02R6-R9)

**Testing and Type Safety:**
* Added thorough unit tests for the `useHealthStatus` hook, `HealthIndicator` component, and their integration in the navigation bar. [[1]](diffhunk://#diff-f5540eccb9d7d822567138254d73f7c06bffc3034227aa719d6cc58cd18f5688R1-R110) [[2]](diffhunk://#diff-8bd8ea831b101c2f0011aa03c75cd2b167c5b7b2fa0f899adbd945f4813d149dR4-R5) [[3]](diffhunk://#diff-8bd8ea831b101c2f0011aa03c75cd2b167c5b7b2fa0f899adbd945f4813d149dR27-R48) [[4]](diffhunk://#diff-8bd8ea831b101c2f0011aa03c75cd2b167c5b7b2fa0f899adbd945f4813d149dR106-R178) [[5]](diffhunk://#diff-4cb6b396312f10bc8caa000a1485ac0f4c5b5b7bb7d80621d4eaa720e059199aR1-R216)
* Ensured type safety by defining `HealthResponse` and `HealthStatus` types in both backend and frontend code. [[1]](diffhunk://#diff-8a40055b584661825aac3ed28064f6d68bfc20f7f5504ee1277bdc497f4e2f2fR9-R13) [[2]](diffhunk://#diff-2fa89f695d65b0930879b6ef532eea2bfa76de081d27af139ab387b0a899e6beR14-R20)

**Version Handling:**
* Refactored version display to read directly from `package.json` via a new `version` module, with tests to verify correctness. [[1]](diffhunk://#diff-d257492b127bcb4a720712e61bb9523df21ea5227d3a69b6d0aa23b07b767b3eR1-R3) [[2]](diffhunk://#diff-a41fcecdd9e0138c1809c739cc16508463e1c4e535c62524f86ed49fc1250d02L46-R59) [[3]](diffhunk://#diff-c3a454829e04657998cbd7df93b7a44c0a4e0199a656bd4e3e5b7b2bfa3065e3R1-R7)

These changes enable real-time feedback of server health for users, improve reliability, and ensure robust test coverage for the new feature.