### PR TITLE
Add not found page

### DIFF
--- a/cyber-query-ai-frontend/src/app/layout.tsx
+++ b/cyber-query-ai-frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import "./globals.css";
+import Footer from "@/components/Footer";
 import Navigation from "@/components/Navigation";
 
 export const metadata: Metadata = {
@@ -46,9 +47,10 @@ export default function RootLayout({
       <body>
         <div className="min-h-screen bg-[var(--background)]">
           <Navigation />
-          <main className="container mx-auto px-4 py-8 max-w-6xl">
+          <main className="container mx-auto px-4 py-8 max-w-6xl pb-20">
             {children}
           </main>
+          <Footer />
         </div>
       </body>
     </html>

--- a/cyber-query-ai-frontend/src/app/not-found.tsx
+++ b/cyber-query-ai-frontend/src/app/not-found.tsx
@@ -48,12 +48,6 @@ export default function NotFound() {
           </p>
         </div>
       </div>
-
-      {/* Terminal-style footer */}
-      <div className="mt-12 text-[var(--text-muted)] text-sm font-mono">
-        <span className="text-[var(--neon-green)]">cyber@query:~$</span>
-        <span className="ml-2">navigate --help</span>
-      </div>
     </div>
   );
 }

--- a/cyber-query-ai-frontend/src/app/not-found.tsx
+++ b/cyber-query-ai-frontend/src/app/not-found.tsx
@@ -1,0 +1,59 @@
+import Image from "next/image";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-[60vh] flex flex-col items-center justify-center text-center space-y-8">
+      {/* Logo */}
+      <div className="flex items-center space-x-4 mb-8">
+        <Image
+          src="/logo.svg"
+          alt="CyberQueryAI Logo"
+          width={64}
+          height={64}
+          className="neon-glow animate-pulse-neon"
+          priority
+        />
+        <div className="text-2xl font-bold neon-glow text-[var(--text-primary)]">
+          CyberQueryAI
+        </div>
+      </div>
+
+      {/* Error Message */}
+      <div className="space-y-4">
+        <h1 className="text-6xl font-bold text-[var(--neon-red)] neon-glow">
+          404
+        </h1>
+        <h2 className="text-2xl font-semibold text-[var(--text-primary)]">
+          Page Not Found
+        </h2>
+        <div className="max-w-md mx-auto space-y-2">
+          <p className="text-[var(--text-secondary)]">
+            The page you&apos;re looking for doesn&apos;t exist.
+          </p>
+          <p className="text-[var(--text-secondary)]">
+            It might have been moved, deleted, or never existed.
+          </p>
+        </div>
+      </div>
+
+      {/* Navigation Tip */}
+      <div className="terminal-border rounded-lg p-6">
+        <h2 className="text-2xl font-bold text-[var(--text-primary)] mb-4 flex items-center">
+          🧠 Tip
+        </h2>
+        <div className="text-[var(--text-secondary)] space-y-4">
+          <p>
+            Use the navigation bar above to explore CyberQueryAI&apos;s
+            features.
+          </p>
+        </div>
+      </div>
+
+      {/* Terminal-style footer */}
+      <div className="mt-12 text-[var(--text-muted)] text-sm font-mono">
+        <span className="text-[var(--neon-green)]">cyber@query:~$</span>
+        <span className="ml-2">navigate --help</span>
+      </div>
+    </div>
+  );
+}

--- a/cyber-query-ai-frontend/src/components/Footer.tsx
+++ b/cyber-query-ai-frontend/src/components/Footer.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { version } from "../lib/version";
+
+const Footer = () => {
+  return (
+    <footer className="fixed bottom-0 left-0 right-0 bg-[var(--background-secondary)] border-t border-[var(--terminal-border)] py-3 px-4 z-40">
+      <div className="container mx-auto max-w-6xl">
+        <div className="text-[var(--text-muted)] text-sm font-mono text-center flex flex-wrap justify-center gap-4">
+          <span className="text-[var(--neon-green)]">cyber@query:~$</span>
+          <span>--version v{version}</span>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default Footer;

--- a/cyber-query-ai-frontend/src/components/Navigation.tsx
+++ b/cyber-query-ai-frontend/src/components/Navigation.tsx
@@ -5,8 +5,6 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 
-import { version } from "../lib/version";
-
 import HealthIndicator from "./HealthIndicator";
 
 const Navigation = () => {
@@ -72,9 +70,6 @@ const Navigation = () => {
               <div className="flex flex-col">
                 <div className="text-xl sm:text-xl font-bold neon-glow text-[var(--text-primary)] nav-logo-text">
                   CyberQueryAI
-                </div>
-                <div className="text-xs text-[var(--text-muted)] hidden sm:block nav-version">
-                  v{version}
                 </div>
               </div>
             </Link>

--- a/cyber-query-ai-frontend/src/components/__tests__/Footer.test.tsx
+++ b/cyber-query-ai-frontend/src/components/__tests__/Footer.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+
+import { version } from "../../lib/version";
+import Footer from "../Footer";
+
+describe("Footer", () => {
+  it("renders the footer component", () => {
+    render(<Footer />);
+
+    const footer = screen.getByRole("contentinfo");
+    expect(footer).toBeInTheDocument();
+  });
+
+  it("displays the terminal prompt", () => {
+    render(<Footer />);
+
+    expect(screen.getByText("cyber@query:~$")).toBeInTheDocument();
+  });
+
+  it("displays the version information", () => {
+    render(<Footer />);
+
+    expect(screen.getByText(`--version v${version}`)).toBeInTheDocument();
+  });
+
+  it("has fixed positioning at the bottom", () => {
+    render(<Footer />);
+
+    const footer = screen.getByRole("contentinfo");
+    expect(footer).toHaveClass("fixed", "bottom-0", "left-0", "right-0");
+  });
+
+  it("has proper z-index for overlay", () => {
+    render(<Footer />);
+
+    const footer = screen.getByRole("contentinfo");
+    expect(footer).toHaveClass("z-40");
+  });
+
+  it("has terminal styling", () => {
+    render(<Footer />);
+
+    const footer = screen.getByRole("contentinfo");
+    expect(footer).toHaveClass(
+      "bg-[var(--background-secondary)]",
+      "border-t",
+      "border-[var(--terminal-border)]"
+    );
+  });
+
+  it("has responsive layout with flexbox", () => {
+    render(<Footer />);
+
+    const contentDiv = screen.getByText("cyber@query:~$").closest("div");
+    expect(contentDiv).toHaveClass(
+      "text-center",
+      "flex",
+      "flex-wrap",
+      "justify-center",
+      "gap-4"
+    );
+  });
+
+  it("has monospace font styling", () => {
+    render(<Footer />);
+
+    const contentDiv = screen.getByText("cyber@query:~$").closest("div");
+    expect(contentDiv).toHaveClass("font-mono", "text-sm");
+  });
+
+  it("has neon green color for terminal prompt", () => {
+    render(<Footer />);
+
+    const terminalPrompt = screen.getByText("cyber@query:~$");
+    expect(terminalPrompt).toHaveClass("text-[var(--neon-green)]");
+  });
+
+  it("has proper container constraints", () => {
+    render(<Footer />);
+
+    const container = screen
+      .getByRole("contentinfo")
+      .querySelector(".container");
+    expect(container).toHaveClass("mx-auto", "max-w-6xl");
+  });
+
+  it("renders with semantic footer element", () => {
+    render(<Footer />);
+
+    const footer = screen.getByRole("contentinfo");
+    expect(footer.tagName).toBe("FOOTER");
+  });
+
+  it("includes version from version library", () => {
+    render(<Footer />);
+
+    // Test that the version is actually dynamic and comes from the version library
+    const versionText = screen.getByText(`--version v${version}`);
+    expect(versionText).toBeInTheDocument();
+
+    // Ensure it's not hardcoded by checking the import
+    expect(typeof version).toBe("string");
+  });
+});

--- a/cyber-query-ai-frontend/src/components/__tests__/Navigation.test.tsx
+++ b/cyber-query-ai-frontend/src/components/__tests__/Navigation.test.tsx
@@ -3,7 +3,6 @@ import { usePathname } from "next/navigation";
 import React from "react";
 
 import { useHealthStatus } from "../../lib/useHealthStatus";
-import { version } from "../../lib/version";
 import Navigation from "../Navigation";
 
 // Mock Next.js Link component
@@ -50,11 +49,6 @@ describe("Navigation", () => {
   it("renders the CyberQueryAI logo", () => {
     render(<Navigation />);
     expect(screen.getByText("CyberQueryAI")).toBeInTheDocument();
-  });
-
-  it("renders version number", () => {
-    render(<Navigation />);
-    expect(screen.getByText(`v${version}`)).toBeInTheDocument();
   });
 
   it("renders all navigation items", () => {


### PR DESCRIPTION
This pull request introduces a new `Footer` component to the CyberQueryAI frontend, adds a custom 404 "Not Found" page, and refactors version display logic. The Footer now displays version information and a terminal-style prompt at the bottom of all pages, while version info is removed from the Navigation bar. Comprehensive tests are added for the Footer component to ensure its correct rendering and styling.

**New Features and UI Improvements:**

* Added a new `Footer` component with fixed positioning, terminal-style prompt, and dynamic version information sourced from the version library (`cyber-query-ai-frontend/src/components/Footer.tsx`, `cyber-query-ai-frontend/src/app/layout.tsx`). [[1]](diffhunk://#diff-6b426c99636ddfe10644626410ed4b724848511e3902e4e3955756ee6bebd28eR1-R18) [[2]](diffhunk://#diff-359429fc6cd431814506f349625a170ad405691bcfe55708c73d6d1056c98bb4R4) [[3]](diffhunk://#diff-359429fc6cd431814506f349625a170ad405691bcfe55708c73d6d1056c98bb4L49-R53)
* Implemented a custom 404 "Not Found" page with branding, error messaging, and navigation tips (`cyber-query-ai-frontend/src/app/not-found.tsx`).

**Refactoring and Code Cleanup:**

* Removed version information from the Navigation bar and related imports, consolidating version display in the new Footer (`cyber-query-ai-frontend/src/components/Navigation.tsx`, `cyber-query-ai-frontend/src/components/__tests__/Navigation.test.tsx`). [[1]](diffhunk://#diff-a41fcecdd9e0138c1809c739cc16508463e1c4e535c62524f86ed49fc1250d02L8-L9) [[2]](diffhunk://#diff-a41fcecdd9e0138c1809c739cc16508463e1c4e535c62524f86ed49fc1250d02L76-L78) [[3]](diffhunk://#diff-8bd8ea831b101c2f0011aa03c75cd2b167c5b7b2fa0f899adbd945f4813d149dL6) [[4]](diffhunk://#diff-8bd8ea831b101c2f0011aa03c75cd2b167c5b7b2fa0f899adbd945f4813d149dL55-L59)

**Testing:**

* Added a comprehensive test suite for the Footer component to verify correct rendering, styling, dynamic version info, and semantic markup (`cyber-query-ai-frontend/src/components/__tests__/Footer.test.tsx`).