### PR TITLE
Add frontend code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Check with mypy
         run: |
           uv run -m mypy .
-  test:
+  pytest:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,10 @@ jobs:
       - name: Test with pytest
         run: |
           uv run -m pytest --cov-report html
-      - name: Upload coverage report
+      - name: Upload backend coverage report
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
+          name: backend-coverage-report
           path: htmlcov
   frontend:
     runs-on: ubuntu-latest
@@ -98,7 +98,12 @@ jobs:
       - name: Run formatting check
         run: npm run format:check
       - name: Run tests
-        run: npm run test
+        run: npm run test:coverage
+      - name: Upload frontend coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage-report
+          path: cyber-query-ai-frontend/coverage
   version-check:
     runs-on: ubuntu-latest
     steps:

--- a/cyber-query-ai-frontend/jest.config.js
+++ b/cyber-query-ai-frontend/jest.config.js
@@ -27,10 +27,10 @@ const customJestConfig = {
   coverageReporters: ["text", "lcov", "html", "json"],
   coverageThreshold: {
     global: {
-      branches: 70,
-      functions: 70,
-      lines: 70,
-      statements: 70,
+      branches: 30,
+      functions: 30,
+      lines: 30,
+      statements: 30,
     },
   },
 };

--- a/cyber-query-ai-frontend/jest.config.js
+++ b/cyber-query-ai-frontend/jest.config.js
@@ -13,6 +13,26 @@ const customJestConfig = {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
   testEnvironment: "jest-environment-jsdom",
+
+  // Coverage configuration
+  collectCoverage: false,
+  collectCoverageFrom: [
+    "src/**/*.{js,jsx,ts,tsx}",
+    "!src/**/*.d.ts",
+    "!src/**/*.stories.{js,jsx,ts,tsx}",
+    "!src/**/__mocks__/**",
+    "!src/**/node_modules/**",
+  ],
+  coverageDirectory: "coverage",
+  coverageReporters: ["text", "lcov", "html", "json"],
+  coverageThreshold: {
+    global: {
+      branches: 70,
+      functions: 70,
+      lines: 70,
+      statements: 70,
+    },
+  },
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/cyber-query-ai-frontend/package.json
+++ b/cyber-query-ai-frontend/package.json
@@ -12,6 +12,9 @@
     "format:check": "prettier --check .",
     "type-check": "tsc --noEmit",
     "test": "jest",
+    "test:coverage": "jest --coverage",
+    "test:coverage:watch": "jest --coverage --watch",
+    "test:coverage:open": "jest --coverage && start coverage/lcov-report/index.html",
     "quality": "npm run type-check && npm run lint:check && npm run format:check",
     "quality:fix": "npm run type-check && npm run format && npm run lint"
   },


### PR DESCRIPTION
This pull request introduces frontend and backend test coverage reporting to the CI workflow, updates naming conventions for coverage artifacts, and adds configuration for collecting coverage in the frontend. The changes improve visibility into test coverage for both backend and frontend codebases and standardize artifact naming for clarity.

### CI workflow improvements

* Added separate jobs for backend (`pytest`) and frontend coverage reporting in `.github/workflows/ci.yml`, including steps to upload coverage reports as distinct artifacts. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL55-R55) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL74-R77) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL101-R106)
* Renamed coverage artifact names to `backend-coverage-report` and `frontend-coverage-report` for clarity. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL74-R77) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL101-R106)

### Frontend coverage configuration

* Added coverage configuration to `cyber-query-ai-frontend/jest.config.js`, specifying which files to include/exclude, coverage output directory, report formats, and global coverage thresholds.
* Updated `cyber-query-ai-frontend/package.json` to add scripts for running tests with coverage, watching coverage, and opening the coverage report in a browser.