### PR TITLE
Update UI

### DIFF
--- a/cyber-query-ai-frontend/src/app/globals.css
+++ b/cyber-query-ai-frontend/src/app/globals.css
@@ -139,16 +139,6 @@ body {
   color: var(--text-secondary);
   position: relative;
   overflow-x: auto;
-  display: flex;
-  align-items: flex-start;
-  gap: 0.5rem;
-}
-
-.command-box:before {
-  content: "$";
-  color: var(--text-primary);
-  font-weight: bold;
-  flex-shrink: 0;
 }
 
 /* Mobile Navigation Styles */

--- a/cyber-query-ai-frontend/src/components/CommandBox.tsx
+++ b/cyber-query-ai-frontend/src/components/CommandBox.tsx
@@ -65,7 +65,10 @@ const CommandBox = ({ commands, isLoading }: CommandBoxProps) => {
 
           return (
             <div key={index} className="command-box group relative">
-              <div className="flex items-center justify-between">
+              <div className="flex items-center justify-between w-full">
+                <span className="text-[var(--text-primary)] font-bold mr-2 flex-shrink-0">
+                  $
+                </span>
                 <code className="text-[var(--text-secondary)] break-all flex-1 mr-2">
                   {sanitizedCommand}
                 </code>

--- a/cyber-query-ai-frontend/src/components/CommandBox.tsx
+++ b/cyber-query-ai-frontend/src/components/CommandBox.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 import { sanitizeOutput, isCommandSafe } from "@/lib/sanitization";
 
 interface CommandBoxProps {
@@ -8,6 +10,18 @@ interface CommandBoxProps {
 }
 
 const CommandBox = ({ commands, isLoading }: CommandBoxProps) => {
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
+
+  const handleCopy = async (command: string, index: number) => {
+    try {
+      await navigator.clipboard?.writeText(command);
+      setCopiedIndex(index);
+      setTimeout(() => setCopiedIndex(null), 2000);
+    } catch {
+      // Failed to copy to clipboard
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="space-y-4">
@@ -47,6 +61,7 @@ const CommandBox = ({ commands, isLoading }: CommandBoxProps) => {
         {commands.map((command, index) => {
           const sanitizedCommand = sanitizeOutput(command);
           const safe = isCommandSafe(sanitizedCommand);
+          const isCopied = copiedIndex === index;
 
           return (
             <div key={index} className="command-box group relative">
@@ -54,20 +69,25 @@ const CommandBox = ({ commands, isLoading }: CommandBoxProps) => {
                 <code className="text-[var(--text-secondary)] break-all flex-1 mr-2">
                   {sanitizedCommand}
                 </code>
-                {!safe && (
-                  <div className="text-[var(--neon-red)] text-xs font-bold whitespace-nowrap flex-shrink-0">
-                    ⚠️ POTENTIALLY UNSAFE
-                  </div>
-                )}
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  {!safe && (
+                    <div className="text-[var(--neon-red)] text-xs font-bold whitespace-nowrap">
+                      ⚠️ POTENTIALLY UNSAFE
+                    </div>
+                  )}
+                  <button
+                    onClick={() => handleCopy(sanitizedCommand, index)}
+                    className="px-2 py-1 bg-[var(--surface-elevated)] hover:bg-[var(--surface-hover)]
+                               border border-[var(--border-color)] rounded text-xs
+                               text-[var(--text-muted)] hover:text-[var(--text-primary)]
+                               transition-all duration-200 flex items-center gap-1"
+                    title={isCopied ? "Copied!" : "Copy to clipboard"}
+                  >
+                    {isCopied ? "✓" : "📋"}
+                    <span>{isCopied ? "Copied" : "Copy"}</span>
+                  </button>
+                </div>
               </div>
-              <button
-                onClick={() => navigator.clipboard?.writeText(sanitizedCommand)}
-                className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity
-                           text-[var(--text-muted)] hover:text-[var(--text-primary)] text-sm"
-                title="Copy to clipboard"
-              >
-                📋
-              </button>
             </div>
           );
         })}

--- a/cyber-query-ai-frontend/src/components/ScriptBox.tsx
+++ b/cyber-query-ai-frontend/src/components/ScriptBox.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 import { sanitizeOutput } from "@/lib/sanitization";
 
 interface ScriptBoxProps {
@@ -9,6 +11,18 @@ interface ScriptBoxProps {
 }
 
 const ScriptBox = ({ script, language, isLoading }: ScriptBoxProps) => {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard?.writeText(sanitizeOutput(script));
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch {
+      // Failed to copy to clipboard
+    }
+  };
+
   if (isLoading) {
     return (
       <div className="space-y-4">
@@ -41,21 +55,26 @@ const ScriptBox = ({ script, language, isLoading }: ScriptBoxProps) => {
 
   return (
     <div className="space-y-4">
-      <h3 className="text-lg font-semibold text-[var(--text-primary)]">
-        📜 Generated Script ({language}):
-      </h3>
-      <div className="command-box group relative max-h-96 overflow-y-auto">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-[var(--text-primary)]">
+          📜 Generated Script ({language}):
+        </h3>
+        <button
+          onClick={handleCopy}
+          className="px-3 py-2 bg-[var(--surface-elevated)] hover:bg-[var(--surface-hover)]
+                     border border-[var(--border-color)] rounded text-sm
+                     text-[var(--text-muted)] hover:text-[var(--text-primary)]
+                     transition-all duration-200 flex items-center gap-2"
+          title={isCopied ? "Copied!" : "Copy to clipboard"}
+        >
+          {isCopied ? "✓" : "📋"}
+          <span>{isCopied ? "Copied" : "Copy Script"}</span>
+        </button>
+      </div>
+      <div className="command-box max-h-96 overflow-y-auto">
         <pre className="text-[var(--text-secondary)] whitespace-pre-wrap break-words">
           <code>{sanitizedScript}</code>
         </pre>
-        <button
-          onClick={() => navigator.clipboard?.writeText(sanitizedScript)}
-          className="absolute top-2 right-2 opacity-0 group-hover:opacity-100 transition-opacity
-                     text-[var(--text-muted)] hover:text-[var(--text-primary)] text-sm"
-          title="Copy to clipboard"
-        >
-          📋
-        </button>
       </div>
     </div>
   );

--- a/cyber_query_ai/chatbot.py
+++ b/cyber_query_ai/chatbot.py
@@ -82,7 +82,7 @@ class Chatbot:
         template = (
             f"{base_template}"
             f"{JSON_FORMATTING_RULES}"
-            "- Do NOT include markdown code blocks (```python, ```) in the script content\n"
+            "- ENSURE you DO NOT include markdown code blocks (```python, ```) in the script content\n"
             "- The script should be plain text code without formatting\n"
             "- The explanation must be ONE continuous string, not multiple separate strings\n"
             "- Use \\n for line breaks within strings\n"


### PR DESCRIPTION
This pull request improves the user experience and reliability of the copy-to-clipboard feature in both the `CommandBox` and `ScriptBox` components, refines their styling, and updates their associated tests for better coverage and accuracy. The changes also clarify prompt instructions for script generation in the backend.

**Component improvements and UI changes:**

* Replaced the CSS-based dollar sign prefix in `.command-box:before` with an inline JSX element for better layout control and removed unnecessary flex and gap styles from `body {}` in `globals.css`.
* Updated `CommandBox` and `ScriptBox` to use React state for copy feedback, showing "Copied" for 2 seconds after a successful copy, and made the copy buttons always visible instead of only on hover. [[1]](diffhunk://#diff-e0fa8494cf06de4abce1badb8e5d841a2c67c03ae83eb7a8eae01f80e4d6b5bbR13-R24) [[2]](diffhunk://#diff-e0fa8494cf06de4abce1badb8e5d841a2c67c03ae83eb7a8eae01f80e4d6b5bbR64-R94) [[3]](diffhunk://#diff-101922ea625434712414632c0669f0ae2534cc3ad169050e7b0ee9a1e9c07371R14-R25) [[4]](diffhunk://#diff-101922ea625434712414632c0669f0ae2534cc3ad169050e7b0ee9a1e9c07371R58-R78)
* Improved visual structure and accessibility of copy buttons, including clearer labels and feedback indicators in both components. [[1]](diffhunk://#diff-e0fa8494cf06de4abce1badb8e5d841a2c67c03ae83eb7a8eae01f80e4d6b5bbR64-R94) [[2]](diffhunk://#diff-101922ea625434712414632c0669f0ae2534cc3ad169050e7b0ee9a1e9c07371R58-R78)

**Testing enhancements:**

* Refactored tests for `CommandBox` and `ScriptBox` to mock clipboard and sanitization functions, verify "Copied" feedback, and check that copy buttons are always visible and properly labeled. [[1]](diffhunk://#diff-bc9c5e2c8608b7815c3200ed1f08fd039f35695bf0a9239b660aae6da7e2da47L1-R14) [[2]](diffhunk://#diff-bc9c5e2c8608b7815c3200ed1f08fd039f35695bf0a9239b660aae6da7e2da47L55-R95) [[3]](diffhunk://#diff-bc9c5e2c8608b7815c3200ed1f08fd039f35695bf0a9239b660aae6da7e2da47R120-R144) [[4]](diffhunk://#diff-169c5ada783d45a3bf4301caff9ae3ae4cdfd5aec7f5631b670055eed948f552L1-R9) [[5]](diffhunk://#diff-169c5ada783d45a3bf4301caff9ae3ae4cdfd5aec7f5631b670055eed948f552L43-R54) [[6]](diffhunk://#diff-169c5ada783d45a3bf4301caff9ae3ae4cdfd5aec7f5631b670055eed948f552L59-R87)
* Simplified and clarified test logic for style and structure assertions, removing hover-dependent checks and focusing on persistent UI elements. [[1]](diffhunk://#diff-bc9c5e2c8608b7815c3200ed1f08fd039f35695bf0a9239b660aae6da7e2da47L55-R95) [[2]](diffhunk://#diff-169c5ada783d45a3bf4301caff9ae3ae4cdfd5aec7f5631b670055eed948f552L116-R142)

**Backend prompt clarification:**

* Updated the script generation prompt in `chatbot.py` to more strongly emphasize that markdown code blocks should not be included in generated scripts.