### PR TITLE
Fix release notes step

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -109,8 +109,7 @@ jobs:
 
       - uses: javidahmed64592/actions-template-python/actions/docker/generate-release-notes@main
         if: steps.check_repo_name.outputs.should_release == 'true' &&
-          steps.check_tag.outputs.tag_exists == 'false' &&
-          github.event.repository.name != 'python-template-server'
+          steps.check_tag.outputs.tag_exists == 'false'
         id: release_notes
         with:
           version: ${{ steps.get_version.outputs.version }}

--- a/uv.lock
+++ b/uv.lock
@@ -1934,7 +1934,7 @@ wheels = [
 [[package]]
 name = "python-template-server"
 version = "0.1.2"
-source = { git = "https://github.com/javidahmed64592/python-template-server.git#2702bb4f259676085c54b3a61fd4d66a64b32292" }
+source = { git = "https://github.com/javidahmed64592/python-template-server.git#9ac9414db370e37006f55987c243dd167a273e88" }
 dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/docker.yml` workflow configuration, specifically simplifying the condition for generating release notes during the Docker workflow.

- Workflow condition update:
  * Removed the check for `github.event.repository.name != 'python-template-server'` from the condition that determines whether to generate release notes in the Docker workflow, allowing release notes generation regardless of the repository name.